### PR TITLE
Headphone on boot capability and button detection for headphones

### DIFF
--- a/patch_cirrus/patch_cirrus_real84.h
+++ b/patch_cirrus/patch_cirrus_real84.h
@@ -3189,10 +3189,13 @@ static void cs_8409_intmike_linein_resetup(struct hda_codec *codec)
 #define BUTTON_DOWN_PRESS 0x10000
 #define BUTTON_UP_PRESS 0x20000
 #define BUTTON_RELEASE 0x100000
+// pressing the play/pause button on earbuds yields 0x100 on down and 0x200 on up
+#define BUTTON_TOGGLE_DOWN_PRESS 0x100
+#define BUTTON_TOGGLE_UP_PRESS 0x200
 #define BUTTON_DETECT_MAIN 0x1800  // we only see 0x800 but the mask allows for these 2 bits
 #define BUTTON_DETECT 0x40
 #define MIKE_CONNECT 0x02
-#define BUTTONS (BUTTON_UP_PRESS | BUTTON_DOWN_PRESS)
+#define BUTTONS (BUTTON_UP_PRESS | BUTTON_DOWN_PRESS | BUTTON_TOGGLE_UP_PRESS | BUTTON_TOGGLE_DOWN_PRESS)
 #define HSDET_AUTO_DONE 0x02
 #define PDN_DONE 0x01
 
@@ -3229,24 +3232,27 @@ static void cs_8409_interrupt_action(struct hda_codec *codec, int int_response)
                 cs_8409_headset_type_detect_event(codec);
 
                 // and this is where life gets really complicated
-		// if we have a mike we do a button detect - but that leads to an unsolicited response
-		// so we only continue here I think if we dont have a mike
-		if (!(spec->have_mike))
+                // if we have a mike we do a button detect - but that leads to an unsolicited response
+                // so we only continue here I think if we dont have a mike
+                if (!(spec->have_mike))
                 {
                         cs_8409_plugin_event_continued(codec);
                 }
         }
         // not clear what test is here - but this should check what we see - one button interrupt seems to be activated
-	// when doing the button detect
+        // when doing the button detect
         // not sure what the exact button interrupt is - we get 0x140800
         // so the button detect interrupt is 0x0800 - the 0x140000 are actual button interrupts (undocumented for cs42l42)
         else if (int_response & BUTTON_DETECT_MAIN)
         {
-		dev_info(hda_codec_dev(codec), "cs_8409_interrupt_action - buttons detected\n");
-		cs_8409_headset_button_detect_event(codec);
+                dev_info(hda_codec_dev(codec), "cs_8409_interrupt_action - buttons detected\n");
+                cs_8409_headset_button_detect_event(codec);
 
         }
-        else if (((int_response & BUTTON_UP_PRESS) == BUTTON_UP_PRESS) || ((int_response & BUTTON_DOWN_PRESS) == BUTTON_DOWN_PRESS))
+        else if (((int_response & BUTTON_UP_PRESS) == BUTTON_UP_PRESS) ||
+                 ((int_response & BUTTON_DOWN_PRESS) == BUTTON_DOWN_PRESS) ||
+                 ((int_response & BUTTON_TOGGLE_UP_PRESS) == BUTTON_TOGGLE_UP_PRESS) ||
+                 ((int_response & BUTTON_TOGGLE_DOWN_PRESS) == BUTTON_TOGGLE_DOWN_PRESS))
         {
                 dev_info(hda_codec_dev(codec), "cs_8409_interrupt_action - button event on \n");
                 cs_8409_headset_button_event(codec, int_response);
@@ -3255,7 +3261,7 @@ static void cs_8409_interrupt_action(struct hda_codec *codec, int int_response)
         else if (((int_response & BUTTON_RELEASE) == BUTTON_RELEASE))
         {
                 dev_info(hda_codec_dev(codec), "cs_8409_interrupt_action - button event off \n");
-		cs_8409_headset_button_event(codec, int_response);
+                cs_8409_headset_button_event(codec, int_response);
 
         }
         else if ((int_response & PDN_DONE) == PDN_DONE)


### PR DESCRIPTION
I've been able to get headphones to work on boot with some naive function calling.
The implementation isn't great and sometimes will give `cs_8409_read_status_and_clear_interrupt - ERROR - max count exceeded`.

When it doesn't give an error however, it normally works for the remainder of the session (I've measured about a 1/4 chance of it not working after about 50 reboots). An almost inaudible clicking sound will be heard on boot for about 5 seconds, after which audio will kick in and work fine.

My other small change is the addition of the play/pause button for earbuds. I'll be testing more headphones with different button arrangements soon but so far just added an up and down code.