### PR TITLE
Add patch to dnf install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Compiling and installing driver:
 
 **fedora package install**
 ```
-dnf install wget make gcc kernel-devel
+dnf install wget make gcc kernel-devel patch
 ```
 **ubuntu package install**  
 ```


### PR DESCRIPTION
When i tried run ./install.cirrus.driver.sh on my fedora 35 workstation, get `patch: command not found` error

fixed by run `dnf install patch`, before script execution 