### PR TITLE
Added the AUR package in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ apt install gcc linux-headers-generic make patch wget
 ```
 **arch package install**
 ```
+# Install from the AUR
+yay -S linux-headers snd-hda-macbookpro-dkms-git
+# Or install dependencies with pacman and build the driver as described below
 pacman -S gcc linux-headers make patch wget
 ```
 **void package install**


### PR DESCRIPTION
Since you guys recently added DKMS to this repo, I was able to write an Arch PKGBUILD for it. It seems to be working well on my machine (more testing welcome), so I've added it to the AUR and modified the README to include the option of installing the driver using an AUR manager like `yay`.

The AUR package is at [https://aur.archlinux.org/packages/snd-hda-macbookpro-dkms-git](https://aur.archlinux.org/packages/snd-hda-macbookpro-dkms-git)