### PR TITLE
warning: add missing `const` qualifier

### DIFF
--- a/patch_cirrus/patch_cirrus_apple.h
+++ b/patch_cirrus/patch_cirrus_apple.h
@@ -1168,7 +1168,7 @@ static void cs_8409_dump_paths(struct hda_codec *codec, const char *label_string
 static int cs_8409_apple_boot_init(struct hda_codec *codec)
 {
 	struct hda_pcm *info = NULL;
-	struct hda_pcm_stream *hinfo = NULL;
+	const struct hda_pcm_stream *hinfo = NULL;
 	struct cs8409_apple_spec *spec = NULL;
 	//struct snd_kcontrol *kctl = NULL;
 	int pcmcnt = 0;


### PR DESCRIPTION
Tested in a `distrobox create -i archlinux` container

Fixes davidjo/snd_hda_macbookpro#107
