### PR TITLE
Exit if "kernel could not be downloaded"

### DIFF
--- a/install.cirrus.driver.sh
+++ b/install.cirrus.driver.sh
@@ -165,9 +165,9 @@ else
    		wget -c https://cdn.kernel.org/pub/linux/kernel/v$major_version.x/linux-$kernel_version.tar.xz -P $build_dir
 	fi
 
-	set -e
-
 	[[ $? -ne 0 ]] && echo "kernel could not be downloaded...exiting" && exit
+
+	set -e
 
 	tar --strip-components=3 -xvf $build_dir/linux-$kernel_version.tar.xz --directory=build/ linux-$kernel_version/sound/pci/hda
 


### PR DESCRIPTION
Moved `set -e` down a bit to avoid shadowing the failure exit code from `wget`. Demonstration shown below.

Before:
```
$ sudo ./install.cirrus.driver.sh 
Ensure the patch package is installed
--2023-11-29 22:48:56--  https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.7.0.tar.xz
Resolving cdn.kernel.org (cdn.kernel.org)... 199.232.33.176, 2a04:4e42:45::432
Connecting to cdn.kernel.org (cdn.kernel.org)|199.232.33.176|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-11-29 22:48:57 ERROR 404: Not Found.

Failed to download linux-6.7.0.tar.xz
Trying to download base kernel version linux-6.7.tar.xz
This may lead to build failures as too old
If this is an Ubuntu-based distribution this almost certainly will fail to build

--2023-11-29 22:48:57--  https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.7.tar.xz
Resolving cdn.kernel.org (cdn.kernel.org)... 199.232.33.176, 2a04:4e42:45::432
Connecting to cdn.kernel.org (cdn.kernel.org)|199.232.33.176|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-11-29 22:48:57 ERROR 404: Not Found.

tar: build/linux-6.7.tar.xz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

After:
```
$ sudo ./install.cirrus.driver.sh 
Ensure the patch package is installed
--2023-11-29 22:49:24--  https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.7.0.tar.xz
Resolving cdn.kernel.org (cdn.kernel.org)... 199.232.33.176, 2a04:4e42:45::432
Connecting to cdn.kernel.org (cdn.kernel.org)|199.232.33.176|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-11-29 22:49:25 ERROR 404: Not Found.

Failed to download linux-6.7.0.tar.xz
Trying to download base kernel version linux-6.7.tar.xz
This may lead to build failures as too old
If this is an Ubuntu-based distribution this almost certainly will fail to build

--2023-11-29 22:49:25--  https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.7.tar.xz
Resolving cdn.kernel.org (cdn.kernel.org)... 199.232.33.176, 2a04:4e42:45::432
Connecting to cdn.kernel.org (cdn.kernel.org)|199.232.33.176|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-11-29 22:49:25 ERROR 404: Not Found.

kernel could not be downloaded...exiting
```