### PR TITLE
Fix for dkms

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,25 @@ cd snd_hda_macbookpro/
 ./install.cirrus.driver.sh
 reboot
 ```
+
+Dynamic Kernel Module Support (dkms):
+-------------
+
+dkms is a framework which allows kernel modules to be dynamically built for each kernel on your system.
+See here for more details: https://github.com/dell/dkms
+You will need to first install dkms on your system
+
+**install driver via dkms**
+```
+sudo ./install.cirrus.driver.sh -i
+```
+
+**remove driver from dkms**
+Delete driver from dkms:
+```
+sudo dkms remove snd_hda_macbookpro/0.1
+```
+Clean up
+```
+sudo ./install.cirrus.driver.sh -r
+```

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="snd_hda_macbookpro"
 PACKAGE_VERSION="0.1"
-PRE_BUILD="install.cirrus.driver.sh -k $kernelver"
+PRE_BUILD="install.cirrus.driver.sh -k $kernelver --dkms"
 MAKE="make"
 BUILT_MODULE_NAME[0]="snd-hda-codec-cs8409"
 BUILT_MODULE_LOCATION[0]="build/hda"

--- a/install.cirrus.driver.sh
+++ b/install.cirrus.driver.sh
@@ -11,6 +11,7 @@ do
     -k|--kernel) UNAME=$2; [[ -z $UNAME ]] && echo '-k|--kernel must be followed by a kernel version' && exit 1;;
     -r|--remove) dkms_action='remove';;
     -u|--uninstall) dkms_action='remove';;
+	-d|--dkms) dkms=true;;
     (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
     (*) break;;
     esac
@@ -254,14 +255,18 @@ popd > /dev/null
 
 [[ ! $dkms_action == 'install' ]] && [[ ! -d $update_dir ]] && mkdir $update_dir
 
-if [ $PATCH_CIRRUS = true ]; then
-	make PATCH_CIRRUS=1
-	make install PATCH_CIRRUS=1
+# Skipping patch installation since dkms will do it
+if [[ $dkms = false ]]; then
 
-else
-	make KERNELRELEASE=$UNAME
-	make install KERNELRELEASE=$UNAME
+	if [ $PATCH_CIRRUS = true ]; then
+		make PATCH_CIRRUS=1
+		make install PATCH_CIRRUS=1
 
+	else
+		make KERNELRELEASE=$UNAME
+		make install KERNELRELEASE=$UNAME
+
+	fi
 fi
 
 echo -e "\ncontents of $update_dir"


### PR DESCRIPTION
Following davidjo suggestions. Introduction a new dkms flag in the install.cirrus.driver.sh script. This is to fix a problem where install.cirrus.driver.sh was compiling the driver and dkms as well, this would create 2 identical modules creating issues when dkms autoupdate was running during a new kernel update. New flag added to the dkms.conf. Added instruction in README on how to use dkms with these drivers