### PR TITLE
Kai Macmaster - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ The following installation setup provided by leifliddy.
 
 
 
-Compiling and installing driver:
+Compiling and installing driver (run the following commands as root or with sudo):
 -------------
 
 **fedora package install**
 ```
-dnf install gcc kernel-devel make patch wget
+dnf install gcc-12 kernel-devel make patch wget
 ```
 **ubuntu package install**  
 ```
-apt install gcc linux-headers-generic make patch wget
+apt install gcc-12 linux-headers-generic make patch wget
 ```
 **arch package install**
 ```


### PR DESCRIPTION
GCC fails on build because it's using an older version than the default installed in the newer versions of Ubuntu and Fedora - I haven't tested on the other distro's so I didn't change those.