### PR TITLE
fix(dkms): prevent uname -r from overriding target kernel flag

### DIFF
--- a/install.cirrus.driver.pre617.sh
+++ b/install.cirrus.driver.pre617.sh
@@ -6,11 +6,14 @@
 
 set -e
 
+# Initialize empty variable to store the -k flag input safely
+TARGET_UNAME=""
+
 while [ $# -gt 0 ]
 do
     case $1 in
     -i|--install) dkms_action='install';;
-    -k|--kernel) UNAME=$2; [[ -z $UNAME ]] && echo '-k|--kernel must be followed by a kernel version' && exit 1; shift;;
+    -k|--kernel) TARGET_UNAME=$2; [[ -z $TARGET_UNAME ]] && echo '-k|--kernel must be followed by a kernel version' && exit 1; shift;;
     -r|--remove) dkms_action='remove';;
     -u|--uninstall) dkms_action='remove';;
     -d|--dkms) dkms=true;;
@@ -20,7 +23,9 @@ do
     shift
 done
 
-UNAME=${1:-$(uname -r)}
+# Set UNAME prioritizing -k flag, then positional argument $1, and finally falling back to uname -r
+UNAME=${TARGET_UNAME:-${1:-$(uname -r)}}
+
 kernel_version=$(echo $UNAME | cut -d '-' -f1)  #ie 5.2.7
 major_version=$(echo $kernel_version | cut -d '.' -f1)
 minor_version=$(echo $kernel_version | cut -d '.' -f2)

--- a/install.cirrus.driver.sh
+++ b/install.cirrus.driver.sh
@@ -7,11 +7,14 @@ set -e
 # Storing the script arguments before processing them if needed for pre617 script
 script_arguments_pre617="${@}"
 
+# Initialize empty variable to store the -k flag input safely
+TARGET_UNAME=""
+
 while [ $# -gt 0 ]
 do
     case $1 in
     -i|--install) dkms_action='install';;
-    -k|--kernel) UNAME=$2; [[ -z $UNAME ]] && echo '-k|--kernel must be followed by a kernel version' && exit 1; shift;;
+    -k|--kernel) TARGET_UNAME=$2; [[ -z $TARGET_UNAME ]] && echo '-k|--kernel must be followed by a kernel version' && exit 1; shift;;
     -r|--remove) dkms_action='remove';;
     -u|--uninstall) dkms_action='remove';;
     -d|--dkms) dkms=true;;
@@ -21,7 +24,9 @@ do
     shift
 done
 
-UNAME=${1:-$(uname -r)}
+# Set UNAME prioritizing -k flag, then positional argument $1, and finally falling back to uname -r
+UNAME=${TARGET_UNAME:-${1:-$(uname -r)}}
+
 kernel_version=$(echo $UNAME | cut -d '-' -f1)  #ie 5.2.7
 major_version=$(echo $kernel_version | cut -d '.' -f1)
 minor_version=$(echo $kernel_version | cut -d '.' -f2)


### PR DESCRIPTION
When updating a kernel via a package manager, DKMS triggers a build for the newly installed kernel while the system is still booted into the older kernel. DKMS passes this target kernel version to the pre_build script using the `-k` flag.

Previously, the install scripts successfully parsed the `-k` flag but immediately overwrote the `UNAME` variable with `$(uname -r)`. This occurred because the positional arguments were cleared by `shift` during parsing, forcing the fallback assignment.

This commit introduces a `TARGET_UNAME` variable to safely store the parsed `-k` value and prioritizes it when assigning the final `UNAME` variable. The fix has been applied to both the main and legacy install scripts, ensuring backwards compatibility for manual executions.

Resolves #180